### PR TITLE
Name update

### DIFF
--- a/grails-app/controllers/com/cabolabs/ehrserver/openehr/common/change_control/VersionController.groovy
+++ b/grails-app/controllers/com/cabolabs/ehrserver/openehr/common/change_control/VersionController.groovy
@@ -37,7 +37,7 @@ class VersionController {
                 templateId: 'ehr_status.en.v1',
                 isModifiable: true,
                 isQueryable: true,
-                name: new DvTextIndex(
+                    dvTextIndex: new DvTextIndex(
                     value:                "EHR Status",
                     templateId:           "default_ehr_status.en.v1",
                     archetypeId:          "openEHR-EHR-EHR_STATUS.generic.v1",

--- a/grails-app/domain/com/cabolabs/ehrserver/openehr/common/archetyped/Locatable.groovy
+++ b/grails-app/domain/com/cabolabs/ehrserver/openehr/common/archetyped/Locatable.groovy
@@ -12,7 +12,7 @@ class Locatable {
     Date validUntil
     boolean lastVersion = true
 
-    DvTextIndex name
+    DvTextIndex dvTextIndex
 
     static mapping = {
       tablePerHierarchy false

--- a/src/test/groovy/com/cabolabs/ehrserver/openehr/common/change_control/VersionSpec.groovy
+++ b/src/test/groovy/com/cabolabs/ehrserver/openehr/common/change_control/VersionSpec.groovy
@@ -1,6 +1,6 @@
 package com.cabolabs.ehrserver.openehr.common.change_control
 
-import grails.testing.gorm.DomainUnitTest
+
 import spock.lang.Specification
 
 import com.cabolabs.ehrserver.openehr.ehr.EhrStatus
@@ -35,7 +35,7 @@ class VersionSpec extends Specification implements DataTest { //DomainUnitTest<V
                 templateId: 'ehr_status.en.v1',
                 isModifiable: true,
                 isQueryable: true,
-                name: new DvTextIndex(
+                    dvTextIndex: new DvTextIndex(
                     value:                "EHR Status",
                     templateId:           "default_ehr_status.en.v1",
                     archetypeId:          "openEHR-EHR-EHR_STATUS.generic.v1",


### PR DESCRIPTION
Change variable name from name to dvTextIndex
After making change, navigating to http://localhost:8080/version/testCreate results in tables being populated.
Other views haven't been setup so not easy to see in UI, you can check the h2 DB however here - http://localhost:8080/dbconsole

I haven't delved deeply into why this was happening but did notice during a quick debugging session that getClass().name was being called at one point, invoking this in the debugger resulted in the error but changing to getClass().getName() didn't